### PR TITLE
PAY-2952 - Include transactionIds in the ERS payload

### DIFF
--- a/events/events_erspayload.md
+++ b/events/events_erspayload.md
@@ -24,6 +24,7 @@ JSON Attribute | Section | Required? | Type | Details
 id | root | On Submit | String | 
 discountCodeName | root | On Submit | String | 
 transactionId | root | No | String | 
+transactionIds | root | No | Array | 
 submit | root | No | Boolean | 
 contactBillTo | root | On Submit | Contact Information | 
 attendeeList | root | No | Array Attendee Information | 
@@ -67,6 +68,7 @@ attendeeList | root | No | Array Attendee Information |
     }
   ],
   "transactionId":null,
+  "transactionIds":null,
   "submit": true
 }
 ```


### PR DESCRIPTION
[PAY-2952](https://blackthornio.atlassian.net/browse/PAY-2952) - Add transactionIds to eventRegistrationSubmission endpoint for split payments

This pull request includes changes to the `events/events_erspayload.md` file to add a new attribute for handling multiple transaction IDs

Updates to JSON attribute documentation:

* Added `transactionIds` attribute to the list of JSON attributes, indicating it is not required and is of type `Array`. `events/events_erspayload.md`

* Updates to example payload:


[PAY-2952]: https://blackthornio.atlassian.net/browse/PAY-2952?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ