### PR TITLE
PAY-2952 - Include transactionIds in the ERS payload

### DIFF
--- a/events/events_erspayload.md
+++ b/events/events_erspayload.md
@@ -24,6 +24,7 @@ JSON Attribute | Section | Required? | Type | Details
 id | root | On Submit | String | 
 discountCodeName | root | On Submit | String | 
 transactionId | root | No | String | 
+transactionIds | root | No | Array | 
 submit | root | No | Boolean | 
 contactBillTo | root | On Submit | Contact Information | 
 attendeeList | root | No | Array Attendee Information | 
@@ -67,6 +68,7 @@ attendeeList | root | No | Array Attendee Information |
     }
   ],
   "transactionId":null,
+  "transactionIds":null,
   "submit": true
 }
 ```


### PR DESCRIPTION
[PAY-2952](https://blackthornio.atlassian.net/browse/PAY-2952) - Add transactionIds to eventRegistrationSubmission endpoint for split payments

This pull request includes updates to the `events/events_erspayload.md` file to add support for handling multiple transaction IDs. The most important changes include adding a new `transactionIds` attribute to the JSON schema and updating the example payload to reflect this new attribute.

Schema updates:

* [`events/events_erspayload.md`](diffhunk://#diff-d0dec35a25e550c217353d59f6037a0203b9924c84fbed850ad378450a281c61R27): Added `transactionIds` attribute to the JSON schema to allow for multiple transaction IDs.

Example payload updates:

* [`events/events_erspayload.md`](diffhunk://#diff-d0dec35a25e550c217353d59f6037a0203b9924c84fbed850ad378450a281c61R71): Updated example payload to include the new `transactionIds` attribute.

[PAY-2952]: https://blackthornio.atlassian.net/browse/PAY-2952?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ